### PR TITLE
Add option to use pseudonymized name.

### DIFF
--- a/lang/en/jitsi.php
+++ b/lang/en/jitsi.php
@@ -59,6 +59,7 @@ $string['identification'] = 'ID User';
 $string['identificationex'] = 'ID to show in the session';
 $string['username'] = 'Username';
 $string['nameandsurname'] = 'Firstname + Lastname';
+$string['pseudonym'] = 'Pseudonym';
 $string['tokennconfig'] = 'Token configuration';
 $string['tokenconfigurationex'] = 'Empty for servers without token';
 $string['separator'] = 'Separator';

--- a/settings.php
+++ b/settings.php
@@ -28,7 +28,7 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configtext('jitsi_domain', 'Domain', 'Domain Jitsi Server', 'meet.jit.si'));
     $settings->add(new admin_setting_confightmleditor('jitsi_help', get_string('help', 'jitsi'),
         get_string('helpex', 'jitsi'), null));
-    $options = ['username' => get_string('username', 'jitsi'), 'nameandsurname' => get_string('nameandsurname', 'jitsi')];
+    $options = ['username' => get_string('username', 'jitsi'), 'nameandsurname' => get_string('nameandsurname', 'jitsi'), 'pseudonym' => get_string('pseudonym', 'jitsi')];
     $settings->add(new admin_setting_configselect('jitsi_id', get_string('identification', 'jitsi'),
         get_string('identificationex', 'jitsi'), null, $options));
     $sessionoptions = ['Course Shortname', 'Session ID', 'Session Name'];

--- a/view.php
+++ b/view.php
@@ -86,6 +86,9 @@ switch ($CFG->jitsi_id) {
     case 'nameandsurname':
         $nom = $USER->firstname.' '.$USER->lastname;
         break;
+    case 'pseudonym':
+        $nom = md5($USER->username . date('Y-m-d'));
+        break;
 }
 $sessionoptionsparam = ['$course->shortname', '$jitsi->id', '$jitsi->name'];
 $fieldssessionname = $CFG->jitsi_sesionname;


### PR DESCRIPTION
On our system we would prefer not to expose real names to the JITSI-Server. Therefore I suggest to add the option "pseudonym" to the admin-setting "jitsi_id".

I implemented this in settings.php, lang/en/jitsi.php and view.php and tested functionality on Moodle 3.8.3.