### PR TITLE
token_affiliation compability

### DIFF
--- a/session.php
+++ b/session.php
@@ -45,8 +45,10 @@ echo $OUTPUT->header();
 
 if ($teacher == 1) {
       $teacher = true;
+      $affiliation = "owner";
 } else {
       $teacher = false;
+      $affiliation = "member";
 }
 
 $context = context_module::instance($cmid);
@@ -64,7 +66,8 @@ $base64urlheader = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode($h
 
 $payload  = json_encode([
   "context" => [
-  "user" => [
+    "user" => [
+      "affiliation" => $affiliation,
       "avatar" => $avatar,
       "name" => $nombre,
       "email" => "",

--- a/sessionpriv.php
+++ b/sessionpriv.php
@@ -44,8 +44,10 @@ echo $OUTPUT->header();
 
 if ($teacher == 1) {
       $teacher = true;
+      $affiliation = "owner";
 } else {
       $teacher = false;
+      $affiliation = "member";
 }
 
 $header = json_encode([
@@ -57,7 +59,8 @@ $base64urlheader = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode($h
 
 $payload  = json_encode([
   "context" => [
-  "user" => [
+    "user" => [
+      "affiliation" => $affiliation,
       "avatar" => $avatar,
       "name" => $nombre,
       "email" => "",


### PR DESCRIPTION
Hello Sergio,

The `token_affiliation` is a prosody module which manages the user affiliation according to the JWT content (`context -> user -> affiliation`). It's similar to the `token_moderation` module but with a different approch.

[mod_token_affiliation.lua](https://github.com/emrahcom/emrah-buster-templates/blob/master/machines/eb-jitsi/usr/share/jitsi-meet/prosody-plugins/mod_token_affiliation.lua)
[related topic on the Jitsi community forum](https://community.jitsi.org/t/new-prosody-modules-to-control-a-tokenized-room-token-affiliation-and-token-owner-party/79962)

This commit adds the `token_affiliation` support without breaking the `token_moderation` support. 