### PR TITLE
Add option to disable Moodle avatars in Jitsi

### DIFF
--- a/lang/en/jitsi.php
+++ b/lang/en/jitsi.php
@@ -92,3 +92,5 @@ $string['privatesession'] = '{$a} private session';
 $string['myprivatesession'] = 'My private session';
 $string['privatesessions'] = 'Private sessions';
 $string['privatesessionsex'] = 'Add private sessions to user profiles';
+$string['showavatars'] = 'Show avatars in Jitsi';
+$string['showavatarsex'] = 'Show the avatar of the user in Jitsi. If the user has no profile picture this will load the default profile picture from Moodle instead of the initials Jitsi will show when no picture is set.';

--- a/session.php
+++ b/session.php
@@ -35,7 +35,7 @@ $cmid = required_param('cmid', PARAM_INT);
 $nombre = required_param('nom', PARAM_TEXT);
 $session = required_param('ses', PARAM_TEXT);
 $sessionnorm = str_replace(array(' ', ':', '"'), '', $session);
-$avatar = required_param('avatar', PARAM_TEXT);
+$avatar = $CFG->jitsi_showavatars == true ? required_param('avatar', PARAM_TEXT) : null;
 $teacher = required_param('t', PARAM_BOOL);
 require_login($courseid);
 

--- a/sessionpriv.php
+++ b/sessionpriv.php
@@ -35,7 +35,7 @@ $nombre = required_param('nom', PARAM_USERNAME);
 $session = required_param('ses', PARAM_TEXT);
 $user = $DB->get_record('user', array('username' => $session));
 $sessionnorm = str_replace(array(' ', ':', '"'), '', $user->username);
-$avatar = required_param('avatar', PARAM_TEXT);
+$avatar = $CFG->jitsi_showavatars == true ? required_param('avatar', PARAM_TEXT) : null;
 $teacher = required_param('t', PARAM_BOOL);
 
 $PAGE->set_title(get_string('privatesession', 'jitsi', $user->firstname));

--- a/settings.php
+++ b/settings.php
@@ -64,6 +64,8 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configcheckbox('jitsi_privatesessions', get_string('privatesessions', 'jitsi'),
         get_string('privatesessionsex', 'jitsi'), 1));
 
+    $settings->add(new admin_setting_configcheckbox('jitsi_showavatars', get_string('showavatars', 'jitsi'), get_string('showavatarsex', 'jitsi'), 1));
+
     $settings->add(new admin_setting_heading('bookmodeditdefaults',
         get_string('tokennconfig', 'jitsi'), get_string('tokenconfigurationex', 'jitsi')));
     $settings->add(new admin_setting_configtext('jitsi_app_id', get_string('appid', 'jitsi'),


### PR DESCRIPTION
Hello,

In the current state the plugin is sending an avatar to Jitsi, so the user has the same avatar in the conference as on Moodle. This is perfectly fine, as long every user has a unique avatar but creates the issue, that in big conferences with many users who don't have set a profile picture, everyone has the default Moodle picture, instead of the initials Jitsi will show for a user without a profile picture, which makes it much harder to see who is speaking / presend. I would like to propose the creation of a setting which allows the admin of the site to turn on / turn off avatars globally, so that the admin of a instance can decide whether it's useful to show the avatars from Moodle, or if the default behaviour of Jitsi should be used.

I tested my change locally and they seem to work flawlessly, but I'm not quite convinced if this is an acceptable solution for solving this issue. I also hope I did everything right with the pull request, this is my first one.

Greetings & thank you for creating this plugin!