### PR TITLE
Added Moodle mobile app support to plugin

### DIFF
--- a/classes/external.php
+++ b/classes/external.php
@@ -1,0 +1,97 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Jitsi module external API
+ *
+ * @package    mod_jitsi
+ * @category   external
+ * @copyright  2021 Arnes
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+require_once($CFG->libdir . '/externallib.php');
+
+class mod_jitsi_external extends external_api{
+    /**
+     * Returns description of method parameters
+     *
+     * @return external_function_parameters
+     */
+    public static function view_jitsi_parameters() {
+        return new external_function_parameters(
+            array(
+                'cmid' => new external_value(PARAM_INT, 'course module instance id')
+            )
+        );
+    }
+
+    /**
+     * Trigger the course module viewed event.
+     *
+     * @param int $cmid the course module instance id
+     * @return array of warnings and status result
+     * @throws moodle_exception
+     */
+    public static function view_jitsi($cmid) {
+        global $DB;
+
+        $params = self::validate_parameters(self::view_jitsi_parameters(),
+                                            array(
+                                                'cmid' => $cmid
+                                            )
+        );
+        $warnings = array();
+
+        $cm = get_coursemodule_from_id('jitsi', $cmid, 0, false, MUST_EXIST);
+
+        $context = \context_module::instance($cm->id);
+        self::validate_context($context);
+        require_capability('mod/jitsi:view', $context);
+
+        $event = \mod_jitsi\event\course_module_viewed::create(
+            array(
+                'objectid' => $cm->instance,
+                'context' => $context,
+            )
+        );
+        $event->add_record_snapshot('course', $course);
+        $event->add_record_snapshot($cm->modname, $jitsi);
+        $event->trigger();
+
+        $result = array();
+        $result['status'] = true;
+        $result['warnings'] = $warnings;
+        return $result;
+    }
+
+    /**
+     * Returns description of method result value
+     *
+     * @return external_description
+     */
+    public static function view_jitsi_returns() {
+        return new external_single_structure(
+            array(
+                'status' => new external_value(PARAM_BOOL, 'status: true if success'),
+                'warnings' => new external_warnings()
+            )
+        );
+    }
+}

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -1,0 +1,302 @@
+<?php
+namespace mod_jitsi\output;
+ 
+use context_module;
+use context_course;
+
+/**
+ * Mobile output class for jitsi
+ *
+ * @package    mod_jitsi
+ * @copyright  2021 Arnes
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mobile {
+    /**
+     * Returns the Jitsi pre-session view for the mobile app.
+     * @param  array $args Arguments from tool_mobile_get_content WS
+     * @return array HTML, javascript and otherdata
+     */
+    public static function mobile_presession_view($args) {
+        global $CFG, $DB, $OUTPUT, $USER;
+
+        $id = $args['cmid'];
+        $courseid = $args['courseid'];
+
+        if ($id) {
+            $cm = get_coursemodule_from_id('jitsi', $id, 0, false, MUST_EXIST);
+            $course = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
+            $jitsi = $DB->get_record('jitsi', array('id' => $cm->instance), '*', MUST_EXIST);
+        } else {
+            print_error('missingparam');
+        }
+
+        require_login($course, false, $cm, true, true);
+        
+        $context = \context_module::instance($cm->id);
+
+        $event = \mod_jitsi\event\course_module_viewed::create(
+            array(
+                'objectid' => $cm->instance,
+                'context' => $context,
+            )
+        );
+        $event->add_record_snapshot('course', $course);
+        $event->add_record_snapshot($cm->modname, $jitsi);
+        $event->trigger();
+        
+        if (!has_capability('mod/jitsi:view', $context)) {
+            notice(get_string('noviewpermission', 'jitsi'));
+        }
+        
+        $context = \context_course::instance($courseid);
+
+        $roles = get_user_roles($context, $USER->id);
+
+        $rolestr[] = null;
+        foreach ($roles as $role) {
+            $rolestr[] = $role->shortname;
+        }
+        
+        if ($jitsi->intro) {
+            $intro = format_module_intro('jitsi', $jitsi, $cm->id);
+        } else {
+            $intro = "";
+        }
+
+        $moderation = false;
+        if (has_capability('mod/jitsi:moderation', $context)) {
+            $moderation = true;
+        }
+
+        $nom = null;
+        switch ($CFG->jitsi_id) {
+            case 'username':
+                $nom = $USER->username;
+                break;
+            case 'nameandsurname':
+                $nom = $USER->firstname.' '.$USER->lastname;
+                break;
+            case 'alias':
+                break;
+        }
+
+        $fieldssessionname = $CFG->jitsi_sesionname;
+
+        $allowed = explode(',', $fieldssessionname);
+        $max = count($allowed);
+
+        $sesparam = '';
+        $optionsseparator = ['.', '-', '_', ''];
+        for ($i = 0; $i < $max; $i++) {
+            if ($i != $max - 1) {
+                if ($allowed[$i] == 0) {
+                    $sesparam .= string_sanitize($course->shortname).$optionsseparator[$CFG->jitsi_separator];
+                } else if ($allowed[$i] == 1) {
+                    $sesparam .= $jitsi->id.$optionsseparator[$CFG->jitsi_separator];
+                } else if ($allowed[$i] == 2) {
+                    $sesparam .= string_sanitize($jitsi->name).$optionsseparator[$CFG->jitsi_separator];
+                }
+            } else {
+                if ($allowed[$i] == 0) {
+                    $sesparam .= string_sanitize($course->shortname);
+                } else if ($allowed[$i] == 1) {
+                    $sesparam .= $jitsi->id;
+                } else if ($allowed[$i] == 2) {
+                    $sesparam .= string_sanitize($jitsi->name);
+                }
+            }
+        }
+
+        // Make titles more mobile friendly.
+        $help = str_replace(array('<h2>', '<h3>'),'<h1>', $CFG->jitsi_help);
+        $help = str_replace(array('</h2>', '</h3>'),'</h1>', $help);
+        $help = str_replace(array('<h4>', '<h5>', '<h6>'), '<h2>', $help);
+        $help = str_replace(array('</h4>', '</h5>', '</h6>'), '</h2>', $help);
+
+        $avatar = $CFG->wwwroot.'/user/pix.php/'.$USER->id.'/f1.jpg';
+        $data = array(
+            'avatar' => $avatar,
+            'nom' => $nom,
+            'ses' => $sesparam,
+            'courseid' => $course->id,
+            'cmid' => $id,
+            't' => $moderation,
+            'help' => $help,
+            'intro' => $intro,
+            'title' => format_string($jitsi->name),
+            'room' => str_replace(array(' ', ':', '"'), '', $sesparam),
+            'minpretime' => $jitsi->minpretime,
+        );
+
+        $today = getdate();
+        if ($today[0] > (($jitsi->timeopen) - ($jitsi->minpretime * 60))||
+            (in_array('editingteacher', $rolestr) == 1)) {
+                $data['nostart_show'] = false;
+        } else {
+            $data['nostart_show'] = true;
+        }
+
+        return [
+            'templates' => [
+                [
+                    'id' => 'main',
+                    'html' => $OUTPUT->render_from_template('mod_jitsi/mobile_presession_view_page', $data),
+                ],
+            ],
+            'javascript' => '',
+            'otherdata' => '',
+        ];
+    }
+
+    /**
+     * Returns the Jitsi session view for the mobile app.
+     * @param  array $args Arguments from tool_mobile_get_content WS
+     * @return array HTML, javascript and otherdata
+     */
+    public static function mobile_session_view($args) {
+        global $OUTPUT, $CFG;
+
+        $courseid = $args['courseid'];
+        $cmid = $args['cmid'];
+        $nombre = $args['nom'];
+        $session = $args['ses'];
+        $sessionnorm = str_replace(array(' ', ':', '"'), '', $session);
+        $avatar = $args['avatar'];
+        $teacher = $args['t'];
+        
+        require_login($courseid);
+
+        if ($teacher == 1) {
+            $teacher = true;
+            $affiliation = "owner";
+        } else {
+            $teacher = false;
+            $affiliation = "member";
+        }
+
+        $context = context_module::instance($cmid);
+
+        if (!has_capability('mod/jitsi:view', $context)) {
+            notice(get_string('noviewpermission', 'jitsi'));
+        }
+
+        $header = json_encode([
+        "kid" => "jitsi/custom_key_name",
+        "typ" => "JWT",
+        "alg" => "HS256"
+        ], JSON_UNESCAPED_SLASHES);
+        $base64urlheader = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode($header));
+
+        $payload  = json_encode([
+        "context" => [
+            "user" => [
+                "affiliation" => $affiliation,
+                "avatar" => $avatar,
+                "name" => $nombre,
+                "email" => "",
+                "id" => ""
+            ],
+            "group" => ""
+        ],
+        "aud" => "jitsi",
+        "iss" => $CFG->jitsi_app_id,
+        "sub" => $CFG->jitsi_domain,
+        "room" => urlencode($sessionnorm),
+        "exp" => time() + 24 * 3600,
+        "moderator" => $teacher
+
+        ], JSON_UNESCAPED_SLASHES);
+        $base64urlpayload = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode($payload));
+
+        $secret = $CFG->jitsi_secret;
+        $signature = hash_hmac('sha256', $base64urlheader . "." . $base64urlpayload, $secret, true);
+        $base64urlsignature = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode($signature));
+
+        $jwt = $base64urlheader . "." . $base64urlpayload . "." . $base64urlsignature;
+        
+        $streamingoption = '';
+        if ($teacher == true && $CFG->jitsi_livebutton == 1) {
+            $streamingoption = 'livestreaming';
+        }
+
+        $desktop = '';
+        if (has_capability('mod/jitsi:sharedesktop', $context)) {
+            $desktop = 'desktop';
+        }
+
+        $youtubeoption = '';
+        if ($CFG->jitsi_shareyoutube == 1) {
+            $youtubeoption = 'sharedvideo';
+        }
+
+        $bluroption = '';
+        if ($CFG->jitsi_blurbutton == 1) {
+            $bluroption = 'videobackgroundblur';
+        }
+
+        $security = '';
+        if ($CFG->jitsi_securitybutton == 1) {
+            $security = 'security';
+        }
+
+        $invite = '';
+        if ($CFG->jitsi_invitebuttons == 1) {
+            $invite = 'invite';
+        }
+
+        $buttons = "['microphone','camera','closedcaptions','".$desktop."','fullscreen','fodeviceselection','hangup','profile','chat','recording','".$streamingoption."','etherpad','".$youtubeoption."','settings','raisehand','videoquality','filmstrip','".$invite."','feedback','stats','shortcuts','tileview','".$bluroption."','download','help','mute-everyone','".$security."']";
+
+        $data = array();
+        $data['jwt'] = 'jwt='.$jwt;
+
+        $config = 'config.channelLastN='.$CFG->jitsi_channellastcam;
+        $config .= '&config.startWithAudioMuted=true';
+        $config .= '&config.startWithVideoMuted=true';
+        $config .= '&config.disableDeepLinking=true';
+        $data['config'] = $config;
+
+        $interfaceConfig = 'interfaceConfig.TOOLBAR_BUTTONS='.urlencode($buttons);
+        $interfaceConfig .= '&interfaceConfig.SHOW_JITSI_WATERMARK=true';
+        $interfaceConfig .= '&interfaceConfig.JITSI_WATERMARK_LINK = '.urlencode("'".$CFG->jitsi_watermarklink."'");
+        $data['interface_config']=$interfaceConfig;
+
+        $data['is_ios'] = $args['appplatform'] == 'darwin' ? true : false;
+        $data['is_desktop'] = $args['appisdesktop'];
+        $data['jitsi_domain'] = $CFG->jitsi_domain;
+        $data['room'] = $sessionnorm;
+
+        return [
+            'templates' => [
+                [
+                    'id' => 'main',
+                    'html' => $OUTPUT->render_from_template('mod_jitsi/mobile_session_view_page', $data),
+                ],
+            ],
+            'javascript' => '',
+            'otherdata' => json_encode($data),
+        ];
+    }
+
+}
+
+/**
+ * Sanitize strings
+ * @param $string - The string to sanitize.
+ * @param $forcelowercase - Force the string to lowercase?
+ * @param $anal - If set to *true*, will remove all non-alphanumeric characters.
+ */
+function string_sanitize($string, $forcelowercase = true, $anal = false) {
+    $strip = array("~", "`", "!", "@", "#", "$", "%", "^", "&", "*", "(", ")",
+            "_", "=", "+", "[", "{", "]", "}", "\\", "|", ";", ":", "\"",
+            "'", "&#8216;", "&#8217;", "&#8220;", "&#8221;", "&#8211;", "&#8212;",
+            "â€”", "â€“", ",", "<", ".", ">", "/", "?");
+    $clean = trim(str_replace($strip, "", strip_tags($string)));
+    $clean = preg_replace('/\s+/', "-", $clean);
+    $clean = ($anal) ? preg_replace("/[^a-zA-Z0-9]/", "", $clean) : $clean;
+    return ($forcelowercase) ?
+        (function_exists('mb_strtolower')) ?
+            mb_strtolower($clean, 'UTF-8') :
+            strtolower($clean) :
+        $clean;
+}

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -35,15 +35,6 @@ class mobile {
         
         $context = \context_module::instance($cm->id);
 
-        $event = \mod_jitsi\event\course_module_viewed::create(
-            array(
-                'objectid' => $cm->instance,
-                'context' => $context,
-            )
-        );
-        $event->add_record_snapshot('course', $course);
-        $event->add_record_snapshot($cm->modname, $jitsi);
-        $event->trigger();
         
         if (!has_capability('mod/jitsi:view', $context)) {
             notice(get_string('noviewpermission', 'jitsi'));

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -108,11 +108,15 @@ class mobile {
             }
         }
 
+        $help = "";
         // Make titles more mobile friendly.
-        $help = str_replace(array('<h2>', '<h3>'),'<h1>', $CFG->jitsi_help);
-        $help = str_replace(array('</h2>', '</h3>'),'</h1>', $help);
-        $help = str_replace(array('<h4>', '<h5>', '<h6>'), '<h2>', $help);
-        $help = str_replace(array('</h4>', '</h5>', '</h6>'), '</h2>', $help);
+        if($CFG->jitsi_help) {
+            $help = str_replace(array('<h2>', '<h3>'),'<h1>', $CFG->jitsi_help);
+            $help = str_replace(array('</h2>', '</h3>'),'</h1>', $help);
+
+            $help = str_replace(array('<h4>', '<h5>', '<h6>'), '<h2>', $help);
+            $help = str_replace(array('</h4>', '</h5>', '</h6>'), '</h2>', $help);
+        }
 
         $avatar = $CFG->wwwroot.'/user/pix.php/'.$USER->id.'/f1.jpg';
         $data = array(

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -35,7 +35,6 @@ class mobile {
         
         $context = \context_module::instance($cm->id);
 
-        
         if (!has_capability('mod/jitsi:view', $context)) {
             notice(get_string('noviewpermission', 'jitsi'));
         }
@@ -51,6 +50,14 @@ class mobile {
         
         if ($jitsi->intro) {
             $intro = format_module_intro('jitsi', $jitsi, $cm->id);
+
+            // Make titles more mobile friendly.
+            $intro = str_replace(array('<h2', '<h3'),'<h1', $intro);
+            $intro = str_replace(array('</h2>', '</h3>'),'</h1>', $intro);
+
+            $intro = str_replace(array('<h4', '<h5', '<h6'), '<h2', $intro);
+            $intro = str_replace(array('</h4>', '</h5>', '</h6>'), '</h2>', $intro);
+
         } else {
             $intro = "";
         }
@@ -102,10 +109,10 @@ class mobile {
         $help = "";
         // Make titles more mobile friendly.
         if($CFG->jitsi_help) {
-            $help = str_replace(array('<h2>', '<h3>'),'<h1>', $CFG->jitsi_help);
+            $help = str_replace(array('<h2', '<h3'),'<h1', $CFG->jitsi_help);
             $help = str_replace(array('</h2>', '</h3>'),'</h1>', $help);
 
-            $help = str_replace(array('<h4>', '<h5>', '<h6>'), '<h2>', $help);
+            $help = str_replace(array('<h4', '<h5', '<h6'), '<h2', $help);
             $help = str_replace(array('</h4>', '</h5>', '</h6>'), '</h2>', $help);
         }
 

--- a/db/mobile.php
+++ b/db/mobile.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Jitsi module capability definition
+ *
+ * @package    mod_jitsi
+ * @copyright  2021 Arnes
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$addons = [
+    'mod_jitsi' => [ // Plugin identifier
+        'handlers' => [ // Different places where the plugin will display content.
+            'jitsimeeting' => [ // Handler unique name (alphanumeric).
+                'displaydata' => [
+                    'icon' => $CFG->wwwroot . '/mod/jitsi/pix/icon.gif',
+                    'class' => '',
+                ],
+                'delegate' => 'CoreCourseModuleDelegate', // Delegate (where to display the link to the plugin)
+                'method' => 'mobile_presession_view', // Main function in \mod_jitsi\output\mobile
+                'offlinefunctions' => [
+                    'mobile_presession_view' => [],
+                    'mobile_session_view' => [],
+                ], // Function that needs to be downloaded for offline.
+            ],
+        ],
+        'lang' => [ // Language strings that are used in all the handlers.
+            ['pluginname', 'jitsi'],
+            ['instruction', 'jitsi'],
+            ['access', 'jitsi'],
+            ['nostart', 'jitsi'],
+            ['buttonopeninbrowser', 'jitsi'],
+            ['buttonopenwithapp', 'jitsi'],
+            ['buttondownloadapp', 'jitsi'],
+            ['appaccessinfo', 'jitsi'],
+            ['appinstalledtext', 'jitsi'],
+            ['appnotinstalledtext', 'jitsi'],
+            ['desktopaccessinfo', 'jitsi']
+        ],
+    ],
+];

--- a/db/services.php
+++ b/db/services.php
@@ -15,20 +15,21 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Defines the version and other meta-info about the plugin
- *
- * Setting the $plugin->version to 0 prevents the plugin from being installed.
- * See https://docs.moodle.org/dev/version.php for more info.
+ * Jitsi external functions and service definitions.
  *
  * @package    mod_jitsi
- * @copyright  2019 Sergio Comerón Sánchez-Paniagua <sergiocomeron@icloud.com>
+ * @category   external
+ * @copyright  2021 Arnes
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
-$plugin->component = 'mod_jitsi';
-$plugin->version = 2021041700;
-$plugin->release = 'v2.8.4';
-$plugin->requires = 2014051200;
-$plugin->maturity = MATURITY_STABLE;
+$functions = array(
+    'mod_jitsi_view_jitsi' => array(
+        'classname'     => 'mod_jitsi_external',
+        'methodname'    => 'view_jitsi',
+        'description'   => 'Trigger the course module viewed event.',
+        'type'          => 'write',
+        'capabilities'  => 'mod/jitsi:view',
+        'services'      => array(MOODLE_OFFICIAL_MOBILE_SERVICE, 'local_mobile'),
+    ),
+);

--- a/lang/en/jitsi.php
+++ b/lang/en/jitsi.php
@@ -94,3 +94,11 @@ $string['privatesessions'] = 'Private sessions';
 $string['privatesessionsex'] = 'Add private sessions to user profiles';
 $string['showavatars'] = 'Show avatars in Jitsi';
 $string['showavatarsex'] = 'Show the avatar of the user in Jitsi. If the user has no profile picture this will load the default profile picture from Moodle instead of the initials Jitsi will show when no picture is set.';
+
+$string['buttonopeninbrowser'] = 'Open in browser';
+$string['buttonopenwithapp'] = 'Join this meeting using the app';
+$string['buttondownloadapp'] = 'Download application';
+$string['appaccessinfo'] = 'If you want to join the meeting using a mobile device, you will need the Jitsi Meet mobile application.';
+$string['desktopaccessinfo'] = 'If you want to join the meeting, click on the button below to open Jitsi in your browser.';
+$string['appinstalledtext'] = 'If you already have the app:';
+$string['appnotinstalledtext'] = "If you don't have the app yet:";

--- a/templates/mobile_presession_view_page.mustache
+++ b/templates/mobile_presession_view_page.mustache
@@ -1,0 +1,40 @@
+{{=<% %>=}}
+
+<div>
+    <ion-card>
+        <ion-card-header>
+            <ion-card-title>
+                <% title %>
+            </ion-card-title>
+        </ion-card-header>
+
+        <ion-card-content>
+            <%#intro%>
+                <%{ intro }%>
+            <%/intro%>
+            
+            <br>
+            
+            <%#nostart_show%>
+                {{ 'plugin.mod_jitsi.nostart' | translate: {$a: <% minpretime %>} }}
+            <%/nostart_show%>
+            <%^nostart_show%>
+                {{ 'plugin.mod_jitsi.instruction' | translate }}
+                <ion-item>
+                    <button ion-button block color="light" core-site-plugins-new-content component="mod_jitsi" method="mobile_session_view" title="<% room %>" [args]="{cmid: '<% cmid %>', courseid: '<% courseid %>', nom: '<% nom %>', ses: '<% ses %>', avatar: '<% avatar %>', t: '<% t %>'}">
+                        {{ 'plugin.mod_jitsi.access' | translate }}
+                    </button>
+                </ion-item>
+            <%/nostart_show%>
+        </ion-card-content>
+    </ion-card>
+
+    <%#help%>
+        <ion-card>
+            <ion-card-content>
+                <%{ help }%>
+            </ion-card-content>
+        </ion-card>
+    <%/help%>
+
+</div>

--- a/templates/mobile_presession_view_page.mustache
+++ b/templates/mobile_presession_view_page.mustache
@@ -12,9 +12,7 @@
             <%#intro%>
                 <%{ intro }%>
             <%/intro%>
-            
             <br>
-            
             <%#nostart_show%>
                 {{ 'plugin.mod_jitsi.nostart' | translate: {$a: <% minpretime %>} }}
             <%/nostart_show%>
@@ -36,5 +34,7 @@
             </ion-card-content>
         </ion-card>
     <%/help%>
+
+    <span core-site-plugins-call-ws-on-load name="mod_jitsi_view_jitsi" [params]="{cmid: <% cmid %>}" [preSets]="{getFromCache: 0, saveToCache: 0}"></span>
 
 </div>

--- a/templates/mobile_session_view_page.mustache
+++ b/templates/mobile_session_view_page.mustache
@@ -1,0 +1,62 @@
+{{=<% %>=}}
+
+<div>
+    <ion-card>
+        <ion-card-header>
+            <ion-card-title>Jitsi Meet</ion-card-title>
+        </ion-card-header>
+
+        <ion-card-content>
+            <%#is_desktop%>
+                {{ 'plugin.mod_jitsi.desktopaccessinfo' | translate }}
+                <ion-grid>
+                    <ion-row>
+                        <ion-col size="12">
+                            <button ion-button block core-link color="light" href="https://<%jitsi_domain%>/<%room%>?<%jwt%>#jitsi_meet_external_api_id=0&<%config%>&<%interface_config%>">
+                                {{ 'plugin.mod_jitsi.buttonopeninbrowser' | translate }}
+                            </button>
+                        </ion-col>
+                    </ion-row>
+                </ion-grid>
+            <%/is_desktop%>
+
+            <%^is_desktop%>
+                {{ 'plugin.mod_jitsi.appaccessinfo' | translate }}
+                <ion-grid>
+                    <ion-row>
+                        <ion-col size="12">
+                            {{ 'plugin.mod_jitsi.appinstalledtext' | translate }}
+                            <button ion-button block core-link color="light" href="org.jitsi.meet://<%jitsi_domain%>/<%room%>?<%jwt%>#jitsi_meet_external_api_id=0&<%config%>&<%interface_config%>">
+                                {{ 'plugin.mod_jitsi.buttonopenwithapp' | translate }}
+                            </button>
+                        </ion-col>
+                    </ion-row>
+                    <br>
+                    <ion-row>
+                        <ion-col size="12">
+                            {{ 'plugin.mod_jitsi.appnotinstalledtext' | translate }}
+                            <%#is_ios%>
+                                <button ion-button block core-link color="light" href="https://itunes.apple.com/us/app/jitsi-meet/id1165103905">
+                                    {{ 'plugin.mod_jitsi.buttondownloadapp' | translate }}
+                                </button>
+                            <%/is_ios%>
+                            <%^is_ios%>
+                                <button ion-button block core-link color="light" href="https://play.google.com/store/apps/details?id=org.jitsi.meet">
+                                    {{ 'plugin.mod_jitsi.buttondownloadapp' | translate }}
+                                </button>
+                            <%/is_ios%>
+                        </ion-col>
+                    </ion-row>
+                    <ion-row>
+                        <ion-col size="12">
+                            <button ion-button block core-link color="light" href="https://<%jitsi_domain%>/<%room%>?<%jwt%>#jitsi_meet_external_api_id=0&<%config%>&<%interface_config%>">
+                                {{ 'plugin.mod_jitsi.buttonopeninbrowser' | translate }}
+                            </button>
+                        </ion-col>
+                    </ion-row>
+                </ion-grid>
+            <%/is_desktop%>
+        </ion-card-content>
+        </ion-card>
+
+</div>

--- a/templates/mobile_session_view_page.mustache
+++ b/templates/mobile_session_view_page.mustache
@@ -12,7 +12,7 @@
                 <ion-grid>
                     <ion-row>
                         <ion-col size="12">
-                            <button ion-button block core-link color="light" href="https://<%jitsi_domain%>/<%room%>?<%jwt%>#jitsi_meet_external_api_id=0&<%config%>&<%interface_config%>">
+                            <button ion-button block core-link color="light" href="https://<%jitsi_domain%>/<%room%><%jwt%>#jitsi_meet_external_api_id=0&<%config%>&<%interface_config%>">
                                 {{ 'plugin.mod_jitsi.buttonopeninbrowser' | translate }}
                             </button>
                         </ion-col>
@@ -26,7 +26,7 @@
                     <ion-row>
                         <ion-col size="12">
                             {{ 'plugin.mod_jitsi.appinstalledtext' | translate }}
-                            <button ion-button block core-link color="light" href="org.jitsi.meet://<%jitsi_domain%>/<%room%>?<%jwt%>#jitsi_meet_external_api_id=0&<%config%>&<%interface_config%>">
+                            <button ion-button block core-link color="light" href="org.jitsi.meet://<%jitsi_domain%>/<%room%><%jwt%>#jitsi_meet_external_api_id=0&<%config%>&<%interface_config%>">
                                 {{ 'plugin.mod_jitsi.buttonopenwithapp' | translate }}
                             </button>
                         </ion-col>
@@ -49,7 +49,7 @@
                     </ion-row>
                     <ion-row>
                         <ion-col size="12">
-                            <button ion-button block core-link color="light" href="https://<%jitsi_domain%>/<%room%>?<%jwt%>#jitsi_meet_external_api_id=0&<%config%>&<%interface_config%>">
+                            <button ion-button block core-link color="light" href="https://<%jitsi_domain%>/<%room%><%jwt%>#jitsi_meet_external_api_id=0&<%config%>&<%interface_config%>">
                                 {{ 'plugin.mod_jitsi.buttonopeninbrowser' | translate }}
                             </button>
                         </ion-col>

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_jitsi';
-$plugin->version = 2021020300;
+$plugin->version = 2021041600;
 $plugin->release = 'v2.8.4';
 $plugin->requires = 2014051200;
 $plugin->maturity = MATURITY_STABLE;

--- a/view.php
+++ b/view.php
@@ -51,7 +51,6 @@ $event = \mod_jitsi\event\course_module_viewed::create(array(
 $event->add_record_snapshot('course', $PAGE->course);
 $event->add_record_snapshot($PAGE->cm->modname, $jitsi);
 $event->trigger();
-
 $PAGE->set_url('/mod/jitsi/view.php', array('id' => $cm->id));
 $PAGE->set_title(format_string($jitsi->name));
 $PAGE->set_heading(format_string($course->fullname));

--- a/view.php
+++ b/view.php
@@ -51,6 +51,7 @@ $event = \mod_jitsi\event\course_module_viewed::create(array(
 $event->add_record_snapshot('course', $PAGE->course);
 $event->add_record_snapshot($PAGE->cm->modname, $jitsi);
 $event->trigger();
+
 $PAGE->set_url('/mod/jitsi/view.php', array('id' => $cm->id));
 $PAGE->set_title(format_string($jitsi->name));
 $PAGE->set_heading(format_string($course->fullname));


### PR DESCRIPTION
Currently, Moodle mobile app users need to open Jitsi activities in the browser - this can sometimes require another login, making the UX not ideal. This PR adds support for the mobile app, making the UX better.

The usage is very similar to the usage in the browser. When clicking on a Jitsi activity, details of the meeting are shown along with an `Access` button. Users can then click on the `Access` button which takes the user to a page where they are given three options - join the meeting the directly through the Jitsi Meet app, the option of downloading the app which opens either the Android or iOS app store page for Jitsi Meet and the option to open the meeting directly in the browser - this link contains `config.disableDeepLinking=true` which joins the meeting directly without asking to join with the app again. The desktop version of the app offers only the final option.