### PR TITLE
fixed validitytime check

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -158,9 +158,11 @@ class mod_jitsi_mod_form extends moodleform_mod {
         }
 
         // Check validitity time is consistent with open and close times.
-        if (($data['validitytime'] != 0 && $data['timeopen'] != 0 && $data['validitytime'] < $data['timeopen']) ||
-                ($data['validitytime'] != 0 && $data['timeclose'] != 0 && $data['validitytime'] > $data['timeclose'])) {
-            $errors['validitytime'] = get_string('validitytimevalidation', 'jitsi');
+        if (isset($data['validitytime']) && $data['validitytime'] != 0) {
+            if (($data['timeopen'] != 0 && $data['validitytime'] < $data['timeopen']) ||
+                ($data['timeclose'] != 0 && $data['validitytime'] > $data['timeclose'])) {
+                $errors['validitytime'] = get_string('validitytimevalidation', 'jitsi');
+            }
         }
 
         return $errors;


### PR DESCRIPTION
Hi,
there is a check missing in the validation function in mod_form to check if the validitytime key is set in the array. If you haven't enabled the invite link admin setting the key will not be added in the definition function to the data array, but it still checks if the value isn't 0 in the validiation function. Thats why it throws an error, which you only see in debug mode.
Best wishes,
Adrian