### PR TITLE
added timeclose and timeopen to coursemodule info

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1114,6 +1114,13 @@ function jitsi_get_coursemodule_info($coursemodule) {
         $result->customdata['customcompletionrules']['completionminutes'] = $jitsi->completionminutes;
     }
 
+    if ($jitsi->timeopen) {
+        $result->customdata['timeopen'] = $jitsi->timeopen;
+    }
+    if ($jitsi->timeclose) {
+        $result->customdata['timeclose'] = $jitsi->timeclose;
+    }
+
     return $result;
 }
 


### PR DESCRIPTION
Hi,
in order to display the timeopen and timeclose dates in the course overview the date variables need to be added to the customdata array.
Best wishes,
Adrian