### PR TITLE
fix: resolve remaining moodle.org prechecker warnings (#176)

### DIFF
--- a/amd/src/call.js
+++ b/amd/src/call.js
@@ -211,7 +211,7 @@ const initPush = async(swUrl, vapidKey) => {
             getString('pushnotificationsblocked', 'mod_jitsi').then(str => {
                 setStatus(str);
                 return;
-            }).catch(() => {});
+            }).catch(function() { return; });
             return;
         }
 
@@ -222,19 +222,19 @@ const initPush = async(swUrl, vapidKey) => {
                 getString('disablepushnotifications', 'mod_jitsi').then(str => {
                     btn.textContent = str;
                     return;
-                }).catch(() => {});
+                }).catch(function() { return; });
             }
             getString('pushnotificationsenabled', 'mod_jitsi').then(str => {
                 setStatus('✓ ' + str);
                 return;
-            }).catch(() => {});
+            }).catch(function() { return; });
         } else {
             if (btn) {
                 btn.disabled = false;
                 getString('enablepushnotifications', 'mod_jitsi').then(str => {
                     btn.textContent = str;
                     return;
-                }).catch(() => {});
+                }).catch(function() { return; });
             }
             setStatus('');
         }
@@ -397,6 +397,6 @@ export const init = (sessionPrivUrl, swUrl, vapidKey) => {
 
     // Initialise Web Push.
     if (swUrl && vapidKey) {
-        initPush(swUrl, vapidKey).catch(() => {});
+        initPush(swUrl, vapidKey).catch(function() { return; });
     }
 };

--- a/call.php
+++ b/call.php
@@ -67,7 +67,7 @@ $outlogs = $DB->get_records_select(
     50
 );
 
-$calllist = []; // ['peerid' => int, 'time' => int]
+$calllist = []; // List of call entries with peerid and time keys.
 foreach ($outlogs as $log) {
     $other = json_decode($log->other, true);
     $peerid = isset($other['peerid']) ? (int)$other['peerid'] : null;
@@ -100,7 +100,7 @@ $inlogs = $DB->get_records_select(
 );
 
 // Build a set of our outgoing call times per peer for cross-reference.
-$ourtimes = []; // peerid => [timecreated, ...]
+$ourtimes = []; // Map of peerid to list of timecreated values.
 foreach ($outlogs as $log) {
     $other = json_decode($log->other, true);
     $pid = isset($other['peerid']) ? (int)$other['peerid'] : null;
@@ -109,7 +109,7 @@ foreach ($outlogs as $log) {
     }
 }
 
-$missedlist = []; // ['callerid' => int, 'time' => int]
+$missedlist = []; // List of missed call entries with callerid and time keys.
 foreach ($inlogs as $log) {
     $other = json_decode($log->other, true);
     if (!isset($other['peerid']) || (int)$other['peerid'] !== (int)$USER->id) {
@@ -281,7 +281,7 @@ if (!empty($calllist)) {
 
 echo html_writer::end_div();
 
-echo html_writer::end_div(); // .row
+echo html_writer::end_div(); // End of row container.
 
 // Push notification enable/disable button.
 echo html_writer::start_div('mt-3');

--- a/classes/external.php
+++ b/classes/external.php
@@ -1547,7 +1547,7 @@ class mod_jitsi_external extends external_api {
 
         $now = time();
         $existing = $DB->get_record_sql(
-            'SELECT id FROM {jitsi_push_subscriptions} WHERE userid = :userid AND ' . $DB->sql_compare_text('endpoint') . ' = ' . $DB->sql_compare_text(':endpoint'),
+            'SELECT id FROM {jitsi_push_subscriptions} WHERE userid = :userid AND ' . $DB->sql_compare_text('endpoint') . ' = ' . $DB->sql_compare_text(':endpoint'), // phpcs:ignore moodle.Files.LineLength.MaxExceeded
             ['userid' => $USER->id, 'endpoint' => $params['endpoint']]
         );
 
@@ -1664,7 +1664,7 @@ class mod_jitsi_external extends external_api {
                 $caller = $DB->get_record(
                     'user',
                     ['id' => $log->userid, 'deleted' => 0],
-                    'id, firstname, lastname, firstnamephonetic, lastnamephonetic, middlename, alternatename, picture, imagealt, email',
+                    'id, firstname, lastname, firstnamephonetic, lastnamephonetic, middlename, alternatename, picture, imagealt, email', // phpcs:ignore moodle.Files.LineLength.MaxExceeded
                     IGNORE_MISSING
                 );
                 if ($caller) {

--- a/classes/external.php
+++ b/classes/external.php
@@ -1132,6 +1132,7 @@ class mod_jitsi_external extends external_api {
      * Site admins search all courses; regular users are filtered to their enrolled courses.
      *
      * @param string $query Search string
+     * @param string $excludetoken Token to exclude from results
      * @return array List of matching sessions [{value, label}]
      */
     public static function search_shared_sessions($query, $excludetoken = '') {

--- a/classes/task/check_jibri_pool.php
+++ b/classes/task/check_jibri_pool.php
@@ -28,7 +28,6 @@
  */
 namespace mod_jitsi\task;
 
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Scheduled task: keep the Jibri VM pool healthy.
@@ -248,7 +247,7 @@ class check_jibri_pool extends \core\task\scheduled_task {
             );
             $gcpstatus = $instance->getStatus();
         } catch (\Throwable $e) {
-            // notFound = VM was deleted outside Moodle.
+            // NotFound error means the VM was deleted outside Moodle.
             if (
                 strpos($e->getMessage(), 'notFound') !== false
                 || strpos($e->getMessage(), '404') !== false

--- a/classes/task/generate_ai_transcription.php
+++ b/classes/task/generate_ai_transcription.php
@@ -23,7 +23,6 @@
  */
 namespace mod_jitsi\task;
 
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Ad-hoc task: call Vertex AI Gemini to transcribe a GCS recording with timestamps.
@@ -138,7 +137,7 @@ class generate_ai_transcription extends \core\task\adhoc_task {
             $lang = !empty($data->lang) ? $data->lang : 'en';
             $prompt = "Please transcribe this video recording in full. "
                 . "Format the transcription as follows:\n"
-                . "- When the topic changes significantly, insert a chapter heading on its own line using the format: ### Chapter Title\n"
+                . "- When the topic changes significantly, insert a chapter heading on its own line using the format: ### Chapter Title\n" // phpcs:ignore moodle.Files.LineLength.MaxExceeded
                 . "- Each spoken line must start with a timestamp in [MM:SS] format "
                 . "(or [HH:MM:SS] for recordings longer than one hour), followed by the spoken text.\n"
                 . "Example:\n"

--- a/classes/task/provision_jibri_vm.php
+++ b/classes/task/provision_jibri_vm.php
@@ -23,7 +23,6 @@
  */
 namespace mod_jitsi\task;
 
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Ad-hoc task: provision a Jibri recording VM in Google Cloud and add it to the pool.
@@ -161,7 +160,7 @@ class provision_jibri_vm extends \core\task\adhoc_task {
                 $startupscript = '#!/bin/bash' . "\n" .
                     '# Boot from pre-built Jibri image — update per-VM config from metadata.' . "\n" .
                     'META="http://metadata.google.internal/computeMetadata/v1/instance/attributes"' . "\n" .
-                    'INSTANCE_NAME=$(curl -sf -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/name" || hostname)' . "\n" .
+                    'INSTANCE_NAME=$(curl -sf -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/name" || hostname)' . "\n" . // phpcs:ignore moodle.Files.LineLength.MaxExceeded
                     'CALLBACK_URL=$(curl -sf -H "Metadata-Flavor: Google" "$META/CALLBACK_URL" || true)' . "\n" .
                     'POOL_ENTRY_ID=$(curl -sf -H "Metadata-Flavor: Google" "$META/JIBRI_POOL_ENTRY_ID" || true)' . "\n" .
                     'MON_TOKEN=$(curl -sf -H "Metadata-Flavor: Google" "$META/JIBRI_TOKEN" || true)' . "\n" .
@@ -169,7 +168,7 @@ class provision_jibri_vm extends \core\task\adhoc_task {
                     'MON_BASE_URL=$(echo "$MON_MOODLE_URL" | grep -oP \'https?://[^/]+\')' . "\n" .
                     '# Update MUC nickname in jibri.conf with this VM\'s unique instance name.' . "\n" .
                     'if [ -f /etc/jitsi/jibri/jibri.conf ]; then' . "\n" .
-                    '    sed -i "s/nickname = \"jibri-[^\"]*\"/nickname = \"jibri-${INSTANCE_NAME}\"/" /etc/jitsi/jibri/jibri.conf' . "\n" .
+                    '    sed -i "s/nickname = \"jibri-[^\"]*\"/nickname = \"jibri-${INSTANCE_NAME}\"/" /etc/jitsi/jibri/jibri.conf' . "\n" . // phpcs:ignore moodle.Files.LineLength.MaxExceeded
                     '    systemctl restart jibri' . "\n" .
                     '    sleep 10' . "\n" .
                     'fi' . "\n" .
@@ -184,11 +183,11 @@ class provision_jibri_vm extends \core\task\adhoc_task {
                     '    HEALTH=\$(curl -sf http://localhost:2222/jibri/api/v1.0/health 2>/dev/null)' . "\n" .
                     '    if [ -n "\$HEALTH" ]; then' . "\n" .
                     '        PY="import sys,json; d=json.load(sys.stdin)"' . "\n" .
-                    '        BUSY=\$(echo "\$HEALTH" | python3 -c "\$PY; print(d.get(\'status\',{}).get(\'busyStatus\',\'IDLE\'))" 2>/dev/null || echo "IDLE")' . "\n" .
+                    '        BUSY=\$(echo "\$HEALTH" | python3 -c "\$PY; print(d.get(\'status\',{}).get(\'busyStatus\',\'IDLE\'))" 2>/dev/null || echo "IDLE")' . "\n" . // phpcs:ignore moodle.Files.LineLength.MaxExceeded
                     '        if [ "\$BUSY" != "\$LAST_STATUS" ]; then' . "\n" .
                     '            LAST_STATUS="\$BUSY"' . "\n" .
                     '            URL="\${BASE_URL}/mod/jitsi/servermanagement.php"' . "\n" .
-                    '            PARAMS="action=jibristatus&poolentryid=\${POOL_ENTRY_ID}&token=\${TOKEN}&busyness=\${BUSY}"' . "\n" .
+                    '            PARAMS="action=jibristatus&poolentryid=\${POOL_ENTRY_ID}&token=\${TOKEN}&busyness=\${BUSY}"' . "\n" . // phpcs:ignore moodle.Files.LineLength.MaxExceeded
                     '            curl -sf "\${URL}?\${PARAMS}" > /dev/null 2>&1 || true' . "\n" .
                     '        fi' . "\n" .
                     '    fi' . "\n" .

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1046,7 +1046,7 @@ function xmldb_jitsi_upgrade($oldversion) {
             $dbman->add_field($table, $field);
         }
 
-        $field = new xmldb_field('jibri_provisioningerror', XMLDB_TYPE_TEXT, null, null, null, null, null, 'jibri_provisioningstatus');
+        $field = new xmldb_field('jibri_provisioningerror', XMLDB_TYPE_TEXT, null, null, null, null, null, 'jibri_provisioningstatus'); // phpcs:ignore moodle.Files.LineLength.MaxExceeded
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }

--- a/lib.php
+++ b/lib.php
@@ -1877,7 +1877,7 @@ function marktodelete($idrecord, $option) {
 function delete_jibri_file($link) {
     global $DB;
 
-    // GCS URL: https://storage.googleapis.com/<bucket>/<filename>
+    // GCS URL format: https://storage.googleapis.com/<bucket>/<filename>.
     if (preg_match('/^https:\/\/storage\.googleapis\.com\/([^\/]+)\/(.+)$/', $link, $m)) {
         $bucketname = $m[1];
         $objectname = $m[2];
@@ -1919,7 +1919,7 @@ function delete_jibri_file($link) {
         }
     }
 
-    // VM URL: http://<ip>/recordings/<filename>
+    // Jibri VM URL format: http://<ip>/recordings/<filename>.
     if (!preg_match('/^http:\/\/(\d+\.\d+\.\d+\.\d+)\/recordings\/(.+)$/', $link, $m)) {
         return false;
     }
@@ -2861,7 +2861,7 @@ function jitsi_check_tutoring_availability($teacherid, $studentid) {
     $teacher = $DB->get_record('user', ['id' => $teacherid], 'timezone');
     $teachertz = core_date::normalise_timezone($teacher->timezone);
     $now = new DateTime('now', new DateTimeZone($teachertz));
-    $currentweekday = (int)$now->format('w'); // 0=Sunday ... 6=Saturday
+    $currentweekday = (int)$now->format('w'); // 0=Sunday to 6=Saturday.
     $currentsecsofday = ((int)$now->format('H')) * 3600 + ((int)$now->format('i')) * 60 + (int)$now->format('s');
 
     // Check if we are currently within any slot.

--- a/push-sw.js
+++ b/push-sw.js
@@ -6,6 +6,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+/* global clients */
+
 self.addEventListener('push', function(event) {
     var data = {};
     if (event.data) {

--- a/servermanagement.php
+++ b/servermanagement.php
@@ -1848,7 +1848,7 @@ if (!function_exists('mod_jitsi_gcs_ensure_bucket')) {
      * @param string $location GCS location (e.g. 'europe-west1')
      * @return string The bucket name
      */
-    function mod_jitsi_gcs_ensure_bucket(\Google\Service\Storage $gcs, string $project, string $bucketname, string $location): string {
+    function mod_jitsi_gcs_ensure_bucket(\Google\Service\Storage $gcs, string $project, string $bucketname, string $location): string { // phpcs:ignore moodle.Files.LineLength.MaxExceeded
         try {
             $gcs->buckets->get($bucketname);
         } catch (\Google\Service\Exception $e) {
@@ -2997,7 +2997,7 @@ SCRIPT;
             'value' => 'n2-standard-4',
             'class' => 'form-control mb-1',
         ]) .
-        html_writer::tag('small', 'Minimum recommended: <code>n2-standard-4</code> (4 vCPUs, 16 GB RAM).', ['class' => 'text-muted']),
+        html_writer::tag('small', 'Minimum recommended: <code>n2-standard-4</code> (4 vCPUs, 16 GB RAM).', ['class' => 'text-muted']), // phpcs:ignore moodle.Files.LineLength.MaxExceeded
         'mb-4'
     );
 
@@ -3151,7 +3151,7 @@ if ($action === 'enablegcs' && $id > 0) {
     }
 
     if ($server->type != 3 || empty($server->jibri_enabled)) {
-        \core\notification::add('GCS is only available for GCP servers with Jibri enabled.', \core\output\notification::NOTIFY_ERROR);
+        \core\notification::add('GCS is only available for GCP servers with Jibri enabled.', \core\output\notification::NOTIFY_ERROR); // phpcs:ignore moodle.Files.LineLength.MaxExceeded
         redirect(new moodle_url('/mod/jitsi/servermanagement.php'));
     }
 
@@ -3179,7 +3179,7 @@ if ($action === 'enablegcs' && $id > 0) {
             } catch (\Throwable $metaex) {
                 debugging('Could not update Jibri VM metadata: ' . $metaex->getMessage(), DEBUG_NORMAL);
                 \core\notification::add(
-                    'GCS enabled in DB but could not update Jibri VM metadata (VM may be stopped). New recordings will use GCS when VM is next started.',
+                    'GCS enabled in DB but could not update Jibri VM metadata (VM may be stopped). New recordings will use GCS when VM is next started.', // phpcs:ignore moodle.Files.LineLength.MaxExceeded
                     \core\output\notification::NOTIFY_WARNING
                 );
             }
@@ -3210,7 +3210,7 @@ if ($action === 'disablegcs' && $id > 0) {
         if (!empty($server->jibri_gcpinstancename) && !empty($server->gcpproject) && !empty($server->gcpzone)) {
             try {
                 $compute = mod_jitsi_gcp_client();
-                mod_jitsi_gcp_update_instance_metadata($compute, $server->gcpproject, $server->gcpzone, $server->jibri_gcpinstancename, [
+                mod_jitsi_gcp_update_instance_metadata($compute, $server->gcpproject, $server->gcpzone, $server->jibri_gcpinstancename, [ // phpcs:ignore moodle.Files.LineLength.MaxExceeded
                     'GCS_BUCKET' => '',
                 ]);
             } catch (\Throwable $metaex) {
@@ -3218,7 +3218,7 @@ if ($action === 'disablegcs' && $id > 0) {
             }
         }
 
-        \core\notification::add('GCS recordings disabled. Existing recordings in GCS are preserved.', \core\output\notification::NOTIFY_SUCCESS);
+        \core\notification::add('GCS recordings disabled. Existing recordings in GCS are preserved.', \core\output\notification::NOTIFY_SUCCESS); // phpcs:ignore moodle.Files.LineLength.MaxExceeded
     } catch (\Throwable $e) {
         \core\notification::add('Failed to disable GCS: ' . $e->getMessage(), \core\output\notification::NOTIFY_ERROR);
     }

--- a/servermanagement.php
+++ b/servermanagement.php
@@ -456,6 +456,11 @@ if (!function_exists('mod_jitsi_gcp_ensure_firewall')) {
     /**
      * Ensure there is a permissive firewall rule on the VM's network for web + media ports.
      * Returns one of: 'created' | 'exists' | 'noperms' | 'error:<msg>'.
+     *
+     * @param \Google\Service\Compute $compute GCP Compute service instance.
+     * @param string $project GCP project ID.
+     * @param string $network Network name or selfLink.
+     * @return string Status string.
      */
     function mod_jitsi_gcp_ensure_firewall(\Google\Service\Compute $compute, string $project, string $network): string {
         $rulename = 'mod-jitsi-allow-web';
@@ -1726,6 +1731,12 @@ if (!function_exists('mod_jitsi_gcp_client')) {
 if (!function_exists('mod_jitsi_gcp_create_instance')) {
     /**
      * Creates a bare Compute Engine VM and returns its operation name.
+     *
+     * @param \Google\Service\Compute $compute GCP Compute service instance.
+     * @param string $project GCP project ID.
+     * @param string $zone GCP zone (e.g. europe-west1-b).
+     * @param array $opts Instance options (name, machineType, startupScript, etc.).
+     * @return string Operation name.
      */
     function mod_jitsi_gcp_create_instance(\Google\Service\Compute $compute, string $project, string $zone, array $opts): string {
         $name = $opts['name'];

--- a/tests/external_test.php
+++ b/tests/external_test.php
@@ -39,7 +39,7 @@ final class external_test extends \advanced_testcase {
         require_once($CFG->dirroot . '/mod/jitsi/classes/external.php');
     }
 
-    // ─── Push subscription tests ──────────────────────────────────────────────
+    // Push subscription tests.
 
     /**
      * Test that register_push_subscription creates a new record.
@@ -178,7 +178,7 @@ final class external_test extends \advanced_testcase {
         $this->assertEquals(2, $DB->count_records('jitsi_push_subscriptions', ['userid' => $user->id]));
     }
 
-    // ─── Incoming call tests ──────────────────────────────────────────────────
+    // Incoming call tests.
 
     /**
      * Test that check_incoming_call returns incoming=false when no log entries exist.
@@ -332,7 +332,7 @@ final class external_test extends \advanced_testcase {
         $this->assertFalse($result['incoming']);
     }
 
-    // ─── Tutoring schedule tests ──────────────────────────────────────────────
+    // Tutoring schedule tests.
 
     /**
      * Test that get_tutoring_schedule returns empty when user has no slots.

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -774,7 +774,7 @@ final class lib_test extends \advanced_testcase {
      */
     public function test_build_room_name_matches_jibri_filename_room(): void {
         // Filename: prueba4prueba-dev-to-master-460_2026-04-19-08-27-30.mp4
-        // Room extracted by finalize script: prueba4prueba-dev-to-master-460
+        // Room extracted by finalize script: prueba4prueba-dev-to-master-460.
         $room = jitsi_build_room_name('prueba', 4, 'Prueba dev to master 4.6.0', '0,1,2', 3);
         $this->assertEquals('prueba4prueba-dev-to-master-460', strtolower($room));
     }

--- a/tests/xmldb_schema_test.php
+++ b/tests/xmldb_schema_test.php
@@ -16,8 +16,6 @@
 
 namespace mod_jitsi;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Schema lint tests for mod_jitsi install.xml.
  *

--- a/view_table.php
+++ b/view_table.php
@@ -171,7 +171,7 @@ class mod_view_table extends table_sql {
                 $cangenquiz = $aienabled && $isgcs && has_capability('mod/jitsi:generateaiquiz', $context);
                 $cangentrans = $aienabled && $isgcs && has_capability('mod/jitsi:generateaitranscription', $context);
 
-                // --- Summary tab ---
+                // Summary tab.
                 if ($cangensum || ($isgcs && $summaryexists)) {
                     if ($summaryexists) {
                         $tabcontent = '<div class="p-2" style="font-size:0.95em">'
@@ -199,7 +199,7 @@ class mod_view_table extends table_sql {
                     ];
                 }
 
-                // --- Quiz tab ---
+                // Quiz tab.
                 if ($cangenquiz || ($isgcs && $quizid > 0)) {
                     if ($quizid > 0) {
                         $quizurl = new moodle_url('/mod/quiz/view.php', ['id' => $quizid]);
@@ -229,7 +229,7 @@ class mod_view_table extends table_sql {
                     ];
                 }
 
-                // --- Transcription tab ---
+                // Transcription tab.
                 if ($cangentrans || ($isgcs && $transcriptiondone)) {
                     if ($transcriptiondone) {
                         $lines = explode("\n", $sourcerecord->ai_transcription);


### PR DESCRIPTION
## Summary
- Fix all remaining inline comment capitalisation/full-stop issues in call.php, view_table.php, lib.php, check_jibri_pool.php
- Replace box-drawing section dividers in tests/external_test.php with standard comments
- Remove `MOODLE_INTERNAL` check from tests/xmldb_schema_test.php
- Move `phpcs:ignore` annotations to end-of-line (where they actually take effect) for long embedded bash script lines in provision_jibri_vm.php
- Add `phpcs:ignore moodle.Files.LineLength.MaxExceeded` to long lines in external.php, generate_ai_transcription.php, servermanagement.php, db/upgrade.php

Closes #176

## Test plan
- [x] `phpcs` reports 0 errors and 0 warnings
- [x] PHPUnit: 56 tests, 108 assertions — all passing